### PR TITLE
reduce build size with code splitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 # package.lock.json
 package-lock.json
+/build/1.e8080218.js
+/build/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,4 @@ typings/
 
 # package.lock.json
 package-lock.json
-/build/
-/build/
-
-
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,7 @@ typings/
 
 # package.lock.json
 package-lock.json
-/build/1.e8080218.js
-/build/index.html
+/build/
+/build/
+
+

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-chartjs-2": "^2",
     "react-dom": "^16",
     "react-hot-loader": "^4",
+    "react-loadable": "^5.5.0",
     "react-router-dom": "^4",
     "typeface-roboto": "^0.0.54"
   },

--- a/src/components/Graphs/index.jsx
+++ b/src/components/Graphs/index.jsx
@@ -8,12 +8,12 @@ import Loadable from 'react-loadable';
 import Loading from '../Loading';
 
 const Legend = Loadable({
-  loader: () => import('../Legend'),
+  loader: () => import(/* webpackChunkName: 'Legend' */ '../Legend'),
   loading: Loading,
 });
 
 const ChartJSWrapper = Loadable({
-  loader: () => import('../ChartJSWrapper'),
+  loader: () => import(/* webpackChunkName: 'ChartJSWrapper' */ '../ChartJSWrapper'),
   loading: Loading,
 });
 

--- a/src/components/Graphs/index.jsx
+++ b/src/components/Graphs/index.jsx
@@ -4,8 +4,18 @@ import ArrowDownward from '@material-ui/icons/ArrowDownward';
 import { withStyles } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import Legend from '../Legend';
-import ChartJSWrapper from '../ChartJSWrapper';
+import Loadable from 'react-loadable';
+import Loading from '../Loading';
+
+const Legend = Loadable({
+  loader: () => import('../Legend'),
+  loading: Loading,
+});
+
+const ChartJSWrapper = Loadable({
+  loader: () => import('../ChartJSWrapper'),
+  loading: Loading,
+});
 
 const sortOverviewFirst = (a, b) => {
   if (a.includes('overview')) {
@@ -14,7 +24,7 @@ const sortOverviewFirst = (a, b) => {
   if (b.includes('overview')) {
     return 1;
   }
-  return (a <= b ? -1 : 1);
+  return a <= b ? -1 : 1;
 };
 
 const styles = () => ({
@@ -28,30 +38,21 @@ const styles = () => ({
 });
 
 const Graphs = ({
-  classes,
-  benchmarkData,
-  overviewMode,
-  platform,
+  classes, benchmarkData, overviewMode, platform,
 }) => (
   <div>
     {!overviewMode
-      && Object.values(benchmarkData.topLabelsConfig).map(({
-        color, label, suite, url,
-      }) => (
-        label
-          && (
-          <Legend
-            key={suite}
-            label={label}
-            labelColor={color}
-          >
-            <a key={url} href={url} target="_blank" rel="noopener noreferrer">
-               all subbenchmarks
-            </a>
-          </Legend>
-          )
-      ))
-    }
+      && Object.values(benchmarkData.topLabelsConfig).map(
+        ({
+          color, label, suite, url,
+        }) => label && (
+        <Legend key={suite} label={label} labelColor={color}>
+          <a key={url} href={url} target="_blank" rel="noopener noreferrer">
+                all subbenchmarks
+          </a>
+        </Legend>
+        ),
+      )}
     {Object.keys(benchmarkData.graphs)
       .sort(overviewMode ? undefined : sortOverviewFirst)
       .map(key => benchmarkData.graphs[key])
@@ -60,12 +61,18 @@ const Graphs = ({
       }) => (
         <div key={title}>
           <h2 className={classes.benchmarkTitle}>{title}</h2>
-          <a href={jointUrl} target="_blank" rel="noopener noreferrer"><LinkIcon className={classes.linkIcon} /></a>
-          {overviewMode
-            ? <Link to={`/${platform}/${configUID}`} rel="noopener noreferrer"><ArrowDownward className={classes.linkIcon} /></Link>
-            : null
-          }
-          <ChartJSWrapper chartJsData={chartJsData} chartJsOptions={chartJsOptions} />
+          <a href={jointUrl} target="_blank" rel="noopener noreferrer">
+            <LinkIcon className={classes.linkIcon} />
+          </a>
+          {overviewMode ? (
+            <Link to={`/${platform}/${configUID}`} rel="noopener noreferrer">
+              <ArrowDownward className={classes.linkIcon} />
+            </Link>
+          ) : null}
+          <ChartJSWrapper
+            chartJsData={chartJsData}
+            chartJsOptions={chartJsOptions}
+          />
         </div>
       ))}
   </div>

--- a/src/components/Loading/index.jsx
+++ b/src/components/Loading/index.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Loading = () => <div> Loading </div>;
+
+export default Loading;

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -16,12 +16,12 @@ const styles = () => ({
 });
 
 const Pickers = Loadable({
-  loader: () => import('../Pickers'),
+  loader: () => import(/* webpackChunkName: 'Pickers' */ '../Pickers'),
   loading: Loading,
 });
 
 const Slider = Loadable({
-  loader: () => import('../Slider'),
+  loader: () => import(/* webpackChunkName: 'Slider' */ '../Slider'),
   loading: Loading,
 });
 

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { withStyles } from '@material-ui/core/styles';
-import Pickers from '../Pickers';
-import Slider from '../Slider';
+import Loadable from 'react-loadable';
 import { generateLastDaysLabel } from '../../utils/timeRangeUtils';
+import Loading from '../Loading';
 
 const styles = () => ({
   root: {
@@ -13,6 +13,16 @@ const styles = () => ({
     textAlign: 'center',
     padding: '15px',
   },
+});
+
+const Pickers = Loadable({
+  loader: () => import('../Pickers'),
+  loading: Loading,
+});
+
+const Slider = Loadable({
+  loader: () => import('../Slider'),
+  loading: Loading,
 });
 
 class Navigation extends Component {
@@ -27,7 +37,10 @@ class Navigation extends Component {
     const { name, value } = event.target;
     const {
       // eslint-disable-next-line react/prop-types
-      history, platform, benchmark, timeRange,
+      history,
+      platform,
+      benchmark,
+      timeRange,
     } = this.props;
 
     let newPlatform = platform;
@@ -73,4 +86,4 @@ class Navigation extends Component {
 }
 
 // withRouter() allow us to use this.props.history to push a new address
-export default withRouter((withStyles(styles))(Navigation));
+export default withRouter(withStyles(styles)(Navigation));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6744,7 +6744,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15, prop-types@^15.5.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -6967,6 +6967,13 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-loadable@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/react-loadable/-/react-loadable-5.5.0.tgz#582251679d3da86c32aae2c8e689c59f1196d8c4"
+  integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
+  dependencies:
+    prop-types "^15.5.0"
 
 react-router-dom@^4:
   version "4.3.1"


### PR DESCRIPTION
This PR adds code splitting  using import() and react-loadable to take advantage of webpack code splitting to reduce build size.  