### PR TITLE
Added Plugin for persistent tooltip on click

### DIFF
--- a/src/components/Plugins/index.jsx
+++ b/src/components/Plugins/index.jsx
@@ -1,0 +1,41 @@
+import { Chart } from 'react-chartjs-2';
+
+const registerTooltipPlugin = () => {
+  Chart.pluginService.register({
+    id: 'tooltipPlugin',
+    beforeRender(chart) {
+      this.pluginTooltips = [];
+      const globalChartObj = Chart;
+      // Process only if a data point was clicked
+      if (globalChartObj.lastClickedDataPoint) {
+        // As we update all charts to clean any open pluginTooltips
+        // This will make sure only target chart gets updated with tooltip data
+        // eslint-disable-next-line no-underscore-dangle
+        if (globalChartObj.lastClickedDataPoint._chart.chart.id !== chart.id) {
+          return;
+        }
+        // eslint-disable-next-line no-underscore-dangle
+        const datasetIndex = globalChartObj.lastClickedDataPoint._datasetIndex;
+        // eslint-disable-next-line no-underscore-dangle
+        const index = globalChartObj.lastClickedDataPoint._index;
+        this.pluginTooltips.push(new Chart.Tooltip({
+          _chart: chart.chart,
+          _chartInstance: chart,
+          _data: chart.data,
+          _options: chart.options.tooltips,
+          _active: [chart.getDatasetMeta(datasetIndex).data[index]],
+        }, chart));
+      }
+    },
+    afterDatasetsDraw(chart, easing) {
+      Chart.helpers.each(this.pluginTooltips, (tooltip) => {
+        tooltip.initialize();
+        tooltip.update();
+        tooltip.pivot();
+        tooltip.transition(easing).draw();
+      });
+    },
+  });
+};
+
+export default registerTooltipPlugin;

--- a/src/views/Benchmark/index.jsx
+++ b/src/views/Benchmark/index.jsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Chart } from 'react-chartjs-2';
 import CircularIndeterminate from '../../components/CircularIndeterminate';
 import Graphs from '../../components/Graphs';
 import fetchData from '../../utils/fetchData';
+import registerTooltipPlugin from '../../components/Plugins';
 
 class Benchmark extends Component {
   static propTypes = {
@@ -19,6 +21,8 @@ class Benchmark extends Component {
     this.mounted = true;
     const { platform, benchmark, timeRange } = this.props;
     this.fetchData(platform, benchmark, timeRange);
+    registerTooltipPlugin();
+    Chart.defaults.global.onClick = this.handleTooltipClick;
   }
 
   componentDidUpdate(prevProps) {
@@ -33,6 +37,31 @@ class Benchmark extends Component {
 
   componentWillUnmount() {
     this.mounted = false;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  handleTooltipClick(e, items) {
+    const globalChartObj = Chart;
+    // check if the click happened on empty chart space or data point
+    if (items.length > 0) {
+      // Save datapoint clicked as global variable
+      // to make sure only one tooltip opens at a time
+      if (globalChartObj.lastClickedDataPoint === items[0]) {
+        // if same datapoint clicked then set val to null
+        // this is close the open tooltip
+        globalChartObj.lastClickedDataPoint = null;
+      } else {
+        [globalChartObj.lastClickedDataPoint] = items;
+      }
+    } else {
+      // if user clicks on empty chart space then
+      // this will close the open tooltip
+      globalChartObj.lastClickedDataPoint = null;
+    }
+    // As there are multiple charts all needs to be updated
+    Chart.helpers.each(Chart.instances, (chart) => {
+      chart.update();
+    });
   }
 
   async fetchData(platform, benchmark, timeRange) {


### PR DESCRIPTION
@armenzg / @sarah-clements - This is a PR for having tooltip to stay open when user clicks on the data points. Please let me know if any changes are required.

Changes:
1. A new plugin is created which handles the tooltip rendering
2. A new global onClick function is added to trigger the plugin

