### PR TITLE
Refactor config logic (Experimental) WIP

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -6,7 +6,9 @@ import {
 } from 'react-router-dom';
 import Benchmark from '../views/Benchmark';
 import Navigation from '../components/Navigation';
-import { CONFIG } from '../config';
+// import { CONFIG } from '../config';
+import DEFAULT_DESKTOP_BENCHMARKS from '../configuration/js-team/appDefaults';
+
 import validCombination from '../utils/validCombination';
 
 const styles = () => ({
@@ -26,7 +28,7 @@ const App = ({ classes }) => (
           const searchParams = new URLSearchParams(location.search);
           const timeRange = Math.round(searchParams.get('numDays'));
           if (!validCombination(platform, benchmark, timeRange)) {
-            return <Redirect to={CONFIG.default.landingPath} />;
+            return <Redirect to={DEFAULT_DESKTOP_BENCHMARKS.landingPath} />;
           }
           return (
             <div className={classes.container}>
@@ -40,7 +42,7 @@ const App = ({ classes }) => (
           );
         }}
       />
-      <Redirect to={CONFIG.default.landingPath} />
+      <Redirect to={DEFAULT_DESKTOP_BENCHMARKS.landingPath} />
     </Switch>
   </BrowserRouter>
 );

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -6,9 +6,7 @@ import {
 } from 'react-router-dom';
 import Benchmark from '../views/Benchmark';
 import Navigation from '../components/Navigation';
-// import { CONFIG } from '../config';
-import DEFAULT_DESKTOP_BENCHMARKS from '../configuration/js-team/appDefaults';
-
+import DASHBOARD_CONFIG from '../configuration/appDefaults';
 import validCombination from '../utils/validCombination';
 
 const styles = () => ({
@@ -28,8 +26,9 @@ const App = ({ classes }) => (
           const searchParams = new URLSearchParams(location.search);
           const timeRange = Math.round(searchParams.get('numDays'));
           if (!validCombination(platform, benchmark, timeRange)) {
-            return <Redirect to={DEFAULT_DESKTOP_BENCHMARKS.landingPath} />;
+            return <Redirect to={DASHBOARD_CONFIG.landingPath} />;
           }
+          // if valid then navigation banao, aur benchmark banao
           return (
             <div className={classes.container}>
               <Navigation
@@ -42,7 +41,7 @@ const App = ({ classes }) => (
           );
         }}
       />
-      <Redirect to={DEFAULT_DESKTOP_BENCHMARKS.landingPath} />
+      <Redirect to={DASHBOARD_CONFIG.landingPath} />
     </Switch>
   </BrowserRouter>
 );

--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -8,6 +8,7 @@ import Benchmark from '../views/Benchmark';
 import Navigation from '../components/Navigation';
 import DASHBOARD_CONFIG from '../configuration/appDefaults';
 import validCombination from '../utils/validCombination';
+import platforms from '../configuration/js-team/index';
 
 const styles = () => ({
   container: {
@@ -28,13 +29,29 @@ const App = ({ classes }) => (
           if (!validCombination(platform, benchmark, timeRange)) {
             return <Redirect to={DASHBOARD_CONFIG.landingPath} />;
           }
-          // if valid then navigation banao, aur benchmark banao
+
+          const platformOptions = Object.keys(platforms).reduce((res, platformKey) => {
+            res.push({ value: platformKey, label: platforms[platformKey].label });
+            return res;
+          }, []);
+
+          const benchmarkOptions = Object.keys(platforms[platform].benchmarks)
+            .sort().reduce((res, benchmarkKey) => {
+              res.push({
+                value: benchmarkKey,
+                label: platforms[platform].benchmarks[benchmarkKey].label,
+              });
+              return res;
+            }, [{ value: 'overview', label: 'Overview' }]);
+
           return (
             <div className={classes.container}>
               <Navigation
                 platform={platform}
                 benchmark={benchmark}
                 timeRange={timeRange}
+                benchmarkOptions={benchmarkOptions}
+                platformOptions={platformOptions}
               />
               <Benchmark {...match.params} timeRange={timeRange} />
             </div>

--- a/src/components/Navigation/index.jsx
+++ b/src/components/Navigation/index.jsx
@@ -21,6 +21,8 @@ class Navigation extends Component {
     benchmark: PropTypes.string.isRequired,
     platform: PropTypes.string.isRequired,
     timeRange: PropTypes.number.isRequired,
+    benchmarkOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+    platformOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   };
 
   handlePathChange = (event) => {
@@ -49,7 +51,7 @@ class Navigation extends Component {
 
   render() {
     const {
-      classes, platform, benchmark, timeRange,
+      classes, platform, benchmark, timeRange, benchmarkOptions, platformOptions,
     } = this.props;
     return (
       <div className={classes.root}>
@@ -57,6 +59,8 @@ class Navigation extends Component {
           onChange={this.handlePathChange}
           platform={platform}
           benchmark={benchmark}
+          benchmarkOptions={benchmarkOptions}
+          platformOptions={platformOptions}
         />
         <Slider
           identifier="timeRange"

--- a/src/components/Pickers/index.jsx
+++ b/src/components/Pickers/index.jsx
@@ -23,6 +23,7 @@ const Pickers = ({
       onSelection={onChange}
       selectedValue={platform}
       options={
+        // how to pass platforms in picker option?
         Object.keys(CONFIG.platforms).reduce((res, platformKey) => {
           res.push({ value: platformKey, label: CONFIG.platforms[platformKey].label });
           return res;

--- a/src/components/Pickers/index.jsx
+++ b/src/components/Pickers/index.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Picker from '../Picker';
-import { BENCHMARKS, CONFIG } from '../../config';
 
 const styles = () => ({
   root: {
@@ -13,7 +12,7 @@ const styles = () => ({
 });
 
 const Pickers = ({
-  classes, benchmark, onChange, platform,
+  classes, benchmark, onChange, platform, benchmarkOptions, platformOptions,
 }) => (
   <div className={classes.root}>
     <Picker
@@ -22,13 +21,7 @@ const Pickers = ({
       topLabel="Platform"
       onSelection={onChange}
       selectedValue={platform}
-      options={
-        // how to pass platforms in picker option?
-        Object.keys(CONFIG.platforms).reduce((res, platformKey) => {
-          res.push({ value: platformKey, label: CONFIG.platforms[platformKey].label });
-          return res;
-        }, [])
-      }
+      options={platformOptions}
     />
     <Picker
       key="Benchmark selection"
@@ -36,15 +29,7 @@ const Pickers = ({
       topLabel="Benchmark"
       onSelection={onChange}
       selectedValue={benchmark}
-      options={
-        CONFIG.platforms[platform].benchmarks.sort().reduce((res, benchmarkKey) => {
-          res.push({
-            value: benchmarkKey,
-            label: BENCHMARKS[benchmarkKey].label,
-          });
-          return res;
-        }, [{ value: 'overview', label: 'Overview' }])
-      }
+      options={benchmarkOptions}
     />
   </div>
 );
@@ -54,6 +39,8 @@ Pickers.propTypes = ({
   benchmark: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   platform: PropTypes.string.isRequired,
+  benchmarkOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  platformOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 });
 
 export default withStyles(styles)(Pickers);

--- a/src/config.js
+++ b/src/config.js
@@ -298,7 +298,7 @@ export const BENCHMARKS = {
   },
 };
 
-const DEFAULT_SUITES = [
+export const DEFAULT_SUITES = [
   'kraken',
   'motionmark-animometer',
   'motionmark-htmlsuite',
@@ -309,12 +309,6 @@ const DEFAULT_SUITES = [
 ];
 
 export const CONFIG = {
-  default: {
-    landingPath: '/win10/overview?numDays=90',
-    timeRange: 90, // 90 days
-    colors: ['#e55525', '#ffcd02'],
-    labels: ['Firefox', 'Chrome'],
-  },
   platforms: {
     linux64: {
       label: 'Linux 64bit',

--- a/src/configuration/appDefaults.js
+++ b/src/configuration/appDefaults.js
@@ -1,0 +1,16 @@
+const DASHBOARD_CONFIG = {
+  landingPath: '/win10/overview?numDays=90',
+  timeRange: 90, // 90 days
+  colors: ['#e55525', '#ffcd02'],
+  labels: ['Firefox', 'Chrome'],
+};
+
+export const SETTINGS = {
+  frameworks: {
+    TALOS_FRAMEWORK_ID: 1,
+    RAPTOR_FRAMEWORK_ID: 10,
+    JSBENCH_FRAMEWORK_ID: 11,
+  },
+};
+
+export default DASHBOARD_CONFIG;

--- a/src/configuration/appDefaults.js
+++ b/src/configuration/appDefaults.js
@@ -1,16 +1,8 @@
 const DASHBOARD_CONFIG = {
   landingPath: '/win10/overview?numDays=90',
-  timeRange: 90, // 90 days
+  timeRange: 90,
   colors: ['#e55525', '#ffcd02'],
   labels: ['Firefox', 'Chrome'],
-};
-
-export const SETTINGS = {
-  frameworks: {
-    TALOS_FRAMEWORK_ID: 1,
-    RAPTOR_FRAMEWORK_ID: 10,
-    JSBENCH_FRAMEWORK_ID: 11,
-  },
 };
 
 export default DASHBOARD_CONFIG;

--- a/src/configuration/js-team/android.js
+++ b/src/configuration/js-team/android.js
@@ -1,28 +1,37 @@
-import { SETTINGS } from '../appDefaults';
+import SETTINGS from '../perfherderSettings';
 
-const { RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+const { frameworkIds } = SETTINGS;
 
-const ANDROID_CONFIG = {
-  label: 'Android', // This is used for the title of the page
+const AndroidConfig = {
+  label: 'Android',
   benchmarks: {
     speedometer: {
-      label: 'Speedometer', // This is the title for the graph
-      compare: [ // I have changed this to an array
+      label: 'Speedometer',
+      compare: [
         {
           color: '#e55525',
           label: 'Moto G5 (arm7)',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
-          project: 'mozilla-central', // This is new
-          platform: 'android-hw-g5-7-0-arm7-api-16', // This is new
+          frameworkId: frameworkIds.raptor,
+          project: 'mozilla-central',
+          platform: 'android-hw-g5-7-0-arm7-api-16',
           suite: 'raptor-speedometer-geckoview',
           buildType: 'opt',
         },
         {
           color: '#ffcd02',
           label: 'Pixel 2 (arm7)',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
-          project: 'mozilla-central', // This is new
-          platform: 'android-hw-p2-8-0-arm7-api-16', // This is new
+          frameworkId: frameworkIds.raptor,
+          project: 'mozilla-central',
+          platform: 'android-hw-p2-8-0-arm7-api-16',
+          suite: 'raptor-speedometer-geckoview',
+          buildType: 'opt',
+        },
+        {
+          color: '#ffcd02',
+          label: 'Pixel 2 (ARM64)',
+          frameworkId: frameworkIds.raptor,
+          project: 'mozilla-central',
+          platform: 'android-hw-p2-8-0-android-aarch64',
           suite: 'raptor-speedometer-geckoview',
           buildType: 'opt',
         },
@@ -31,4 +40,4 @@ const ANDROID_CONFIG = {
   },
 };
 
-export default ANDROID_CONFIG;
+export default AndroidConfig;

--- a/src/configuration/js-team/android.js
+++ b/src/configuration/js-team/android.js
@@ -1,0 +1,34 @@
+import { SETTINGS } from '../appDefaults';
+
+const { RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+
+const ANDROID_CONFIG = {
+  label: 'Android', // This is used for the title of the page
+  benchmarks: {
+    speedometer: {
+      label: 'Speedometer', // This is the title for the graph
+      compare: [ // I have changed this to an array
+        {
+          color: '#e55525',
+          label: 'Moto G5 (arm7)',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          project: 'mozilla-central', // This is new
+          platform: 'android-hw-g5-7-0-arm7-api-16', // This is new
+          suite: 'raptor-speedometer-geckoview',
+          buildType: 'opt',
+        },
+        {
+          color: '#ffcd02',
+          label: 'Pixel 2 (arm7)',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          project: 'mozilla-central', // This is new
+          platform: 'android-hw-p2-8-0-arm7-api-16', // This is new
+          suite: 'raptor-speedometer-geckoview',
+          buildType: 'opt',
+        },
+      ],
+    },
+  },
+};
+
+export default ANDROID_CONFIG;

--- a/src/configuration/js-team/appDefaults.js
+++ b/src/configuration/js-team/appDefaults.js
@@ -1,0 +1,8 @@
+const DEFAULT_DESKTOP_BENCHMARKS = {
+  landingPath: '/win10/overview?numDays=90',
+  timeRange: 90, // 90 days
+  colors: ['#e55525', '#ffcd02'],
+  labels: ['Firefox', 'Chrome'],
+};
+
+export default DEFAULT_DESKTOP_BENCHMARKS;

--- a/src/configuration/js-team/appDefaults.js
+++ b/src/configuration/js-team/appDefaults.js
@@ -1,8 +1,0 @@
-const DEFAULT_DESKTOP_BENCHMARKS = {
-  landingPath: '/win10/overview?numDays=90',
-  timeRange: 90, // 90 days
-  colors: ['#e55525', '#ffcd02'],
-  labels: ['Firefox', 'Chrome'],
-};
-
-export default DEFAULT_DESKTOP_BENCHMARKS;

--- a/src/configuration/js-team/index.js
+++ b/src/configuration/js-team/index.js
@@ -1,0 +1,35 @@
+import Linux64 from './linux64';
+import MacConfig from './macOS';
+import Win7Config from './win7';
+import Win10Config from './win10';
+import AndroidConfig from './android';
+
+const platforms = {
+  linux64: {
+    label: 'Linux 64bit',
+    platform: 'linux64',
+    benchmarks: Linux64.benchmarks,
+  },
+  mac: {
+    label: 'Mac OS X',
+    platform: 'osx-10-10',
+    benchmarks: MacConfig.benchmarks,
+  },
+  win7: {
+    label: 'Windows 7 32bit',
+    platform: 'windows7-32',
+    benchmarks: Win7Config.benchmarks,
+  },
+  win10: {
+    label: 'Windows 10 64bit',
+    platform: 'windows10-64',
+    benchmarks: Win10Config.benchmarks,
+  },
+  android: {
+    label: 'Android',
+    platform: 'android', // three diff platforms in android
+    benchmarks: AndroidConfig.benchmarks,
+  },
+};
+
+export default platforms;

--- a/src/configuration/js-team/linux64.js
+++ b/src/configuration/js-team/linux64.js
@@ -1,0 +1,319 @@
+import { SETTINGS } from '../appDefaults';
+
+const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID, JSBENCH_FRAMEWORK_ID } = SETTINGS.frameworks;
+
+const LINUX64_CONFIG = {
+  label: 'Linux 64bit',
+  benchmarks: {
+    kraken: {
+      compare: {
+        kraken: {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: TALOS_FRAMEWORK_ID,
+          suite: 'kraken',
+          buildType: 'opt',
+          extraOptions: ['e10s', 'stylo'],
+        },
+      },
+      label: 'Kraken',
+    },
+    'motionmark-animometer': {
+      compare: {
+        'raptor-motionmark-animometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-animometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark Animometer',
+    },
+    'motionmark-htmlsuite': {
+      compare: {
+        'raptor-motionmark-htmlsuite-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-htmlsuite-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark HtmlSuite',
+    },
+    speedometer: {
+      compare: {
+        'raptor-speedometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-speedometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Speedometer',
+    },
+    stylebench: {
+      compare: {
+        'raptor-stylebench-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-firefox',
+          buildType: 'opt',
+        },
+        'raptor-stylebench-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'StyleBench',
+    },
+    sunspider: {
+      compare: {
+        'raptor-sunspider-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-firefox',
+          buildType: 'opt',
+        },
+        'raptor-sunspider-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'SunSpider',
+    },
+    webaudio: {
+      compare: {
+        'raptor-webaudio-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-firefox',
+          buildType: 'opt',
+        },
+        'raptor-webaudio-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'WebAudio',
+    },
+    'assorted-dom': {
+      compare: {
+        'raptor-assorted-dom-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-assorted-dom-firefox',
+          buildType: 'opt',
+        },
+        'raptor-assorted-dom-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-assorted-dom-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Assorted DOM',
+    },
+    ares6: {
+      compare: {
+        'ares6-sm': {
+          color: '#e55525',
+          label: 'SpiderMonkey',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'ares6-sm',
+          buildType: 'opt',
+        },
+        'ares6-v8': {
+          color: '#ffcd02',
+          label: 'Chrome v8',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'ares6-v8',
+          buildType: 'opt',
+        },
+      },
+      labels: ['SpiderMonkey', 'Chrome v8'],
+      label: 'Ares6 (JS shell)',
+    },
+    octane: {
+      compare: {
+        'octane-sm': {
+          color: '#e55525',
+          label: 'SpiderMonkey',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'octane-sm',
+          buildType: 'opt',
+        },
+        'octane-v8': {
+          color: '#ffcd02',
+          label: 'Chrome v8',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'octane-v8',
+          buildType: 'opt',
+        },
+      },
+      labels: ['SpiderMonkey', 'Chrome v8'],
+      label: 'Octane (JS shell)',
+    },
+    'six-speed': {
+      compare: {
+        'six-speed-sm': {
+          color: '#e55525',
+          label: 'SpiderMonkey',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'six-speed-sm',
+          buildType: 'opt',
+        },
+        'six-speed-v8': {
+          color: '#ffcd02',
+          label: 'Chrome v8',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'six-speed-v8',
+          buildType: 'opt',
+        },
+      },
+      labels: ['SpiderMonkey', 'Chrome v8'],
+      label: 'Six Speed (JS shell)',
+    },
+    'sunspider-jsbench': {
+      compare: {
+        'sunspider-sm': {
+          color: '#e55525',
+          label: 'SpiderMonkey',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'sunspider-sm',
+          buildType: 'opt',
+        },
+      },
+      labels: ['SpiderMonkey'],
+      label: 'Sun Spider (JS shell)',
+    },
+    'unity-webgl': {
+      compare: {
+        'raptor-unity-webgl-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-unity-webgl-firefox',
+          buildType: 'opt',
+        },
+        'raptor-unity-webgl-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-unity-webgl-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Unity WebGL',
+    },
+    'wasm-misc': {
+      compare: {
+        'raptor-wasm-misc-firefox': {
+          color: '#e55525',
+          label: 'Firefox (tiering)',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-wasm-misc-firefox',
+          buildType: 'opt',
+        },
+        'raptor-wasm-misc-baseline-firefox': {
+          color: 'red',
+          label: 'Firefox (wasm-baseline)',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-wasm-misc-baseline-firefox',
+          buildType: 'opt',
+        },
+        'raptor-wasm-misc-ion-firefox': {
+          color: 'brown',
+          label: 'Firefox (wasm-ion)',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-wasm-misc-ion-firefox',
+          buildType: 'opt',
+        },
+        'raptor-wasm-misc-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-wasm-misc-chrome',
+          buildType: 'opt',
+        },
+      },
+      colors: ['#e55525', 'red', 'brown', '#ffcd02'],
+      labels: ['Firefox (tiering)', 'Firefox (wasm-baseline)', 'Firefox (wasm-ion)', 'Chrome'],
+      label: 'WebAssembly Embenchen',
+    },
+    'web-tooling': {
+      compare: {
+        'web-tooling-benchmark-sm': {
+          color: '#e55525',
+          label: 'SpiderMonkey',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'web-tooling-benchmark-sm',
+          buildType: 'opt',
+        },
+        'web-tooling-benchmark-v8': {
+          color: '#ffcd02',
+          label: 'Chrome v8',
+          frameworkId: JSBENCH_FRAMEWORK_ID,
+          suite: 'web-tooling-benchmark-v8',
+          buildType: 'opt',
+        },
+      },
+      labels: ['SpiderMonkey', 'Chrome v8'],
+      label: 'Web Tooling (JS shell)',
+    },
+
+  },
+};
+
+// export default LINUX64_CONFIG;
+// 'kraken',
+// 'motionmark-animometer',
+// 'motionmark-htmlsuite',
+// 'speedometer',
+// 'stylebench',
+// 'sunspider',
+// 'webaudio',
+
+// linux extra
+// 'assorted-dom', 'ares6', 'octane', 'six-speed',
+// 'sunspider-jsbench', 'unity-webgl', 'wasm-misc',
+// 'web-tooling'
+
+export default LINUX64_CONFIG;

--- a/src/configuration/js-team/linux64.js
+++ b/src/configuration/js-team/linux64.js
@@ -23,6 +23,7 @@ const Linux64 = {
         'raptor-motionmark-animometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-firefox',
           buildType: 'opt',
@@ -30,6 +31,7 @@ const Linux64 = {
         'raptor-motionmark-animometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-chrome',
           buildType: 'opt',
@@ -42,6 +44,7 @@ const Linux64 = {
         'raptor-motionmark-htmlsuite-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-firefox',
           buildType: 'opt',
@@ -49,6 +52,7 @@ const Linux64 = {
         'raptor-motionmark-htmlsuite-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-chrome',
           buildType: 'opt',
@@ -61,6 +65,7 @@ const Linux64 = {
         'raptor-speedometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-firefox',
           buildType: 'opt',
@@ -68,6 +73,7 @@ const Linux64 = {
         'raptor-speedometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-chrome',
           buildType: 'opt',
@@ -80,6 +86,7 @@ const Linux64 = {
         'raptor-stylebench-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-firefox',
           buildType: 'opt',
@@ -87,6 +94,7 @@ const Linux64 = {
         'raptor-stylebench-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-chrome',
           buildType: 'opt',
@@ -99,6 +107,7 @@ const Linux64 = {
         'raptor-sunspider-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-firefox',
           buildType: 'opt',
@@ -106,6 +115,7 @@ const Linux64 = {
         'raptor-sunspider-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-chrome',
           buildType: 'opt',
@@ -118,6 +128,7 @@ const Linux64 = {
         'raptor-webaudio-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-firefox',
           buildType: 'opt',
@@ -125,6 +136,7 @@ const Linux64 = {
         'raptor-webaudio-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-chrome',
           buildType: 'opt',
@@ -137,6 +149,7 @@ const Linux64 = {
         'raptor-assorted-dom-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-assorted-dom-firefox',
           buildType: 'opt',
@@ -144,6 +157,7 @@ const Linux64 = {
         'raptor-assorted-dom-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-assorted-dom-chrome',
           buildType: 'opt',
@@ -156,6 +170,7 @@ const Linux64 = {
         'ares6-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
+          platform: 'linux64',
           frameworkId: frameworkIds.jsbench,
           suite: 'ares6-sm',
           buildType: 'opt',
@@ -163,6 +178,7 @@ const Linux64 = {
         'ares6-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.jsbench,
           suite: 'ares6-v8',
           buildType: 'opt',
@@ -176,6 +192,7 @@ const Linux64 = {
         'octane-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
+          platform: 'linux64',
           frameworkId: frameworkIds.jsbench,
           suite: 'octane-sm',
           buildType: 'opt',
@@ -183,6 +200,7 @@ const Linux64 = {
         'octane-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.jsbench,
           suite: 'octane-v8',
           buildType: 'opt',
@@ -196,6 +214,7 @@ const Linux64 = {
         'six-speed-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
+          platform: 'linux64',
           frameworkId: frameworkIds.jsbench,
           suite: 'six-speed-sm',
           buildType: 'opt',
@@ -203,6 +222,7 @@ const Linux64 = {
         'six-speed-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.jsbench,
           suite: 'six-speed-v8',
           buildType: 'opt',
@@ -216,6 +236,7 @@ const Linux64 = {
         'sunspider-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
+          platform: 'linux64',
           frameworkId: frameworkIds.jsbench,
           suite: 'sunspider-sm',
           buildType: 'opt',
@@ -229,6 +250,7 @@ const Linux64 = {
         'raptor-unity-webgl-firefox': {
           color: '#e55525',
           label: 'Firefox',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-unity-webgl-firefox',
           buildType: 'opt',
@@ -236,6 +258,7 @@ const Linux64 = {
         'raptor-unity-webgl-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-unity-webgl-chrome',
           buildType: 'opt',
@@ -248,6 +271,7 @@ const Linux64 = {
         'raptor-wasm-misc-firefox': {
           color: '#e55525',
           label: 'Firefox (tiering)',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-firefox',
           buildType: 'opt',
@@ -255,6 +279,7 @@ const Linux64 = {
         'raptor-wasm-misc-baseline-firefox': {
           color: 'red',
           label: 'Firefox (wasm-baseline)',
+          platform: 'linux64',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-baseline-firefox',
           buildType: 'opt',
@@ -263,12 +288,14 @@ const Linux64 = {
           color: 'brown',
           label: 'Firefox (wasm-ion)',
           frameworkId: frameworkIds.raptor,
+          platform: 'linux64',
           suite: 'raptor-wasm-misc-ion-firefox',
           buildType: 'opt',
         },
         'raptor-wasm-misc-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-chrome',
           buildType: 'opt',
@@ -283,6 +310,7 @@ const Linux64 = {
         'web-tooling-benchmark-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
+          platform: 'linux64',
           frameworkId: frameworkIds.jsbench,
           suite: 'web-tooling-benchmark-sm',
           buildType: 'opt',
@@ -290,6 +318,7 @@ const Linux64 = {
         'web-tooling-benchmark-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
+          platform: 'linux64-nightly',
           frameworkId: frameworkIds.jsbench,
           suite: 'web-tooling-benchmark-v8',
           buildType: 'opt',

--- a/src/configuration/js-team/linux64.js
+++ b/src/configuration/js-team/linux64.js
@@ -1,8 +1,8 @@
-import { SETTINGS } from '../appDefaults';
+import SETTINGS from '../perfherderSettings';
 
-const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID, JSBENCH_FRAMEWORK_ID } = SETTINGS.frameworks;
+const { frameworkIds } = SETTINGS;
 
-const LINUX64_CONFIG = {
+const Linux64 = {
   label: 'Linux 64bit',
   benchmarks: {
     kraken: {
@@ -10,7 +10,7 @@ const LINUX64_CONFIG = {
         kraken: {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: TALOS_FRAMEWORK_ID,
+          frameworkId: frameworkIds.talos,
           suite: 'kraken',
           buildType: 'opt',
           extraOptions: ['e10s', 'stylo'],
@@ -23,14 +23,14 @@ const LINUX64_CONFIG = {
         'raptor-motionmark-animometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-animometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-chrome',
           buildType: 'opt',
         },
@@ -42,14 +42,14 @@ const LINUX64_CONFIG = {
         'raptor-motionmark-htmlsuite-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-htmlsuite-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-chrome',
           buildType: 'opt',
         },
@@ -61,14 +61,14 @@ const LINUX64_CONFIG = {
         'raptor-speedometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-firefox',
           buildType: 'opt',
         },
         'raptor-speedometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-chrome',
           buildType: 'opt',
         },
@@ -80,14 +80,14 @@ const LINUX64_CONFIG = {
         'raptor-stylebench-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-firefox',
           buildType: 'opt',
         },
         'raptor-stylebench-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-chrome',
           buildType: 'opt',
         },
@@ -99,14 +99,14 @@ const LINUX64_CONFIG = {
         'raptor-sunspider-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-firefox',
           buildType: 'opt',
         },
         'raptor-sunspider-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-chrome',
           buildType: 'opt',
         },
@@ -118,14 +118,14 @@ const LINUX64_CONFIG = {
         'raptor-webaudio-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-firefox',
           buildType: 'opt',
         },
         'raptor-webaudio-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-chrome',
           buildType: 'opt',
         },
@@ -137,14 +137,14 @@ const LINUX64_CONFIG = {
         'raptor-assorted-dom-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-assorted-dom-firefox',
           buildType: 'opt',
         },
         'raptor-assorted-dom-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-assorted-dom-chrome',
           buildType: 'opt',
         },
@@ -156,14 +156,14 @@ const LINUX64_CONFIG = {
         'ares6-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'ares6-sm',
           buildType: 'opt',
         },
         'ares6-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'ares6-v8',
           buildType: 'opt',
         },
@@ -176,14 +176,14 @@ const LINUX64_CONFIG = {
         'octane-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'octane-sm',
           buildType: 'opt',
         },
         'octane-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'octane-v8',
           buildType: 'opt',
         },
@@ -196,14 +196,14 @@ const LINUX64_CONFIG = {
         'six-speed-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'six-speed-sm',
           buildType: 'opt',
         },
         'six-speed-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'six-speed-v8',
           buildType: 'opt',
         },
@@ -216,7 +216,7 @@ const LINUX64_CONFIG = {
         'sunspider-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'sunspider-sm',
           buildType: 'opt',
         },
@@ -229,14 +229,14 @@ const LINUX64_CONFIG = {
         'raptor-unity-webgl-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-unity-webgl-firefox',
           buildType: 'opt',
         },
         'raptor-unity-webgl-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-unity-webgl-chrome',
           buildType: 'opt',
         },
@@ -248,28 +248,28 @@ const LINUX64_CONFIG = {
         'raptor-wasm-misc-firefox': {
           color: '#e55525',
           label: 'Firefox (tiering)',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-firefox',
           buildType: 'opt',
         },
         'raptor-wasm-misc-baseline-firefox': {
           color: 'red',
           label: 'Firefox (wasm-baseline)',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-baseline-firefox',
           buildType: 'opt',
         },
         'raptor-wasm-misc-ion-firefox': {
           color: 'brown',
           label: 'Firefox (wasm-ion)',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-ion-firefox',
           buildType: 'opt',
         },
         'raptor-wasm-misc-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-wasm-misc-chrome',
           buildType: 'opt',
         },
@@ -283,14 +283,14 @@ const LINUX64_CONFIG = {
         'web-tooling-benchmark-sm': {
           color: '#e55525',
           label: 'SpiderMonkey',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'web-tooling-benchmark-sm',
           buildType: 'opt',
         },
         'web-tooling-benchmark-v8': {
           color: '#ffcd02',
           label: 'Chrome v8',
-          frameworkId: JSBENCH_FRAMEWORK_ID,
+          frameworkId: frameworkIds.jsbench,
           suite: 'web-tooling-benchmark-v8',
           buildType: 'opt',
         },
@@ -302,18 +302,4 @@ const LINUX64_CONFIG = {
   },
 };
 
-// export default LINUX64_CONFIG;
-// 'kraken',
-// 'motionmark-animometer',
-// 'motionmark-htmlsuite',
-// 'speedometer',
-// 'stylebench',
-// 'sunspider',
-// 'webaudio',
-
-// linux extra
-// 'assorted-dom', 'ares6', 'octane', 'six-speed',
-// 'sunspider-jsbench', 'unity-webgl', 'wasm-misc',
-// 'web-tooling'
-
-export default LINUX64_CONFIG;
+export default Linux64;

--- a/src/configuration/js-team/macOS.js
+++ b/src/configuration/js-team/macOS.js
@@ -1,8 +1,8 @@
-import { SETTINGS } from '../appDefaults';
+import SETTINGS from '../perfherderSettings';
 
-const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+const { frameworkIds } = SETTINGS;
 
-const MAC_CONFIG = {
+const MacConfig = {
   label: 'Mac OS X',
   benchmarks: {
     kraken: {
@@ -10,7 +10,7 @@ const MAC_CONFIG = {
         kraken: {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: TALOS_FRAMEWORK_ID,
+          frameworkId: frameworkIds.talos,
           suite: 'kraken',
           buildType: 'opt',
           extraOptions: ['e10s', 'stylo'],
@@ -23,14 +23,14 @@ const MAC_CONFIG = {
         'raptor-motionmark-animometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-animometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-chrome',
           buildType: 'opt',
         },
@@ -42,14 +42,14 @@ const MAC_CONFIG = {
         'raptor-motionmark-htmlsuite-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-htmlsuite-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-chrome',
           buildType: 'opt',
         },
@@ -61,14 +61,14 @@ const MAC_CONFIG = {
         'raptor-speedometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-firefox',
           buildType: 'opt',
         },
         'raptor-speedometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-chrome',
           buildType: 'opt',
         },
@@ -80,14 +80,14 @@ const MAC_CONFIG = {
         'raptor-stylebench-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-firefox',
           buildType: 'opt',
         },
         'raptor-stylebench-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-chrome',
           buildType: 'opt',
         },
@@ -99,14 +99,14 @@ const MAC_CONFIG = {
         'raptor-sunspider-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-firefox',
           buildType: 'opt',
         },
         'raptor-sunspider-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-chrome',
           buildType: 'opt',
         },
@@ -118,14 +118,14 @@ const MAC_CONFIG = {
         'raptor-webaudio-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-firefox',
           buildType: 'opt',
         },
         'raptor-webaudio-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-chrome',
           buildType: 'opt',
         },
@@ -135,4 +135,4 @@ const MAC_CONFIG = {
   },
 };
 
-export default MAC_CONFIG;
+export default MacConfig;

--- a/src/configuration/js-team/macOS.js
+++ b/src/configuration/js-team/macOS.js
@@ -1,0 +1,138 @@
+import { SETTINGS } from '../appDefaults';
+
+const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+
+const MAC_CONFIG = {
+  label: 'Mac OS X',
+  benchmarks: {
+    kraken: {
+      compare: {
+        kraken: {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: TALOS_FRAMEWORK_ID,
+          suite: 'kraken',
+          buildType: 'opt',
+          extraOptions: ['e10s', 'stylo'],
+        },
+      },
+      label: 'Kraken',
+    },
+    'motionmark-animometer': {
+      compare: {
+        'raptor-motionmark-animometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-animometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark Animometer',
+    },
+    'motionmark-htmlsuite': {
+      compare: {
+        'raptor-motionmark-htmlsuite-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-htmlsuite-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark HtmlSuite',
+    },
+    speedometer: {
+      compare: {
+        'raptor-speedometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-speedometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Speedometer',
+    },
+    stylebench: {
+      compare: {
+        'raptor-stylebench-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-firefox',
+          buildType: 'opt',
+        },
+        'raptor-stylebench-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'StyleBench',
+    },
+    sunspider: {
+      compare: {
+        'raptor-sunspider-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-firefox',
+          buildType: 'opt',
+        },
+        'raptor-sunspider-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'SunSpider',
+    },
+    webaudio: {
+      compare: {
+        'raptor-webaudio-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-firefox',
+          buildType: 'opt',
+        },
+        'raptor-webaudio-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'WebAudio',
+    },
+  },
+};
+
+export default MAC_CONFIG;

--- a/src/configuration/js-team/win10.js
+++ b/src/configuration/js-team/win10.js
@@ -1,8 +1,8 @@
-import { SETTINGS } from '../appDefaults';
+import SETTINGS from '../perfherderSettings';
 
-const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+const { frameworkIds } = SETTINGS;
 
-const WIN10_CONFIG = {
+const Win10Config = {
   label: 'Windows 10 64bit',
   benchmarks: {
     kraken: {
@@ -10,7 +10,7 @@ const WIN10_CONFIG = {
         kraken: {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: TALOS_FRAMEWORK_ID,
+          frameworkId: frameworkIds.talos,
           suite: 'kraken',
           buildType: 'opt',
           extraOptions: ['e10s', 'stylo'],
@@ -23,14 +23,14 @@ const WIN10_CONFIG = {
         'raptor-motionmark-animometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-animometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-chrome',
           buildType: 'opt',
         },
@@ -42,14 +42,14 @@ const WIN10_CONFIG = {
         'raptor-motionmark-htmlsuite-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-htmlsuite-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-chrome',
           buildType: 'opt',
         },
@@ -61,14 +61,14 @@ const WIN10_CONFIG = {
         'raptor-speedometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-firefox',
           buildType: 'opt',
         },
         'raptor-speedometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-chrome',
           buildType: 'opt',
         },
@@ -80,14 +80,14 @@ const WIN10_CONFIG = {
         'raptor-stylebench-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-firefox',
           buildType: 'opt',
         },
         'raptor-stylebench-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-chrome',
           buildType: 'opt',
         },
@@ -99,14 +99,14 @@ const WIN10_CONFIG = {
         'raptor-sunspider-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-firefox',
           buildType: 'opt',
         },
         'raptor-sunspider-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-chrome',
           buildType: 'opt',
         },
@@ -118,14 +118,14 @@ const WIN10_CONFIG = {
         'raptor-webaudio-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-firefox',
           buildType: 'opt',
         },
         'raptor-webaudio-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-chrome',
           buildType: 'opt',
         },
@@ -135,4 +135,4 @@ const WIN10_CONFIG = {
   },
 };
 
-export default WIN10_CONFIG;
+export default Win10Config;

--- a/src/configuration/js-team/win10.js
+++ b/src/configuration/js-team/win10.js
@@ -1,0 +1,138 @@
+import { SETTINGS } from '../appDefaults';
+
+const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+
+const WIN10_CONFIG = {
+  label: 'Windows 10 64bit',
+  benchmarks: {
+    kraken: {
+      compare: {
+        kraken: {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: TALOS_FRAMEWORK_ID,
+          suite: 'kraken',
+          buildType: 'opt',
+          extraOptions: ['e10s', 'stylo'],
+        },
+      },
+      label: 'Kraken',
+    },
+    'motionmark-animometer': {
+      compare: {
+        'raptor-motionmark-animometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-animometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark Animometer',
+    },
+    'motionmark-htmlsuite': {
+      compare: {
+        'raptor-motionmark-htmlsuite-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-htmlsuite-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark HtmlSuite',
+    },
+    speedometer: {
+      compare: {
+        'raptor-speedometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-speedometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Speedometer',
+    },
+    stylebench: {
+      compare: {
+        'raptor-stylebench-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-firefox',
+          buildType: 'opt',
+        },
+        'raptor-stylebench-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'StyleBench',
+    },
+    sunspider: {
+      compare: {
+        'raptor-sunspider-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-firefox',
+          buildType: 'opt',
+        },
+        'raptor-sunspider-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'SunSpider',
+    },
+    webaudio: {
+      compare: {
+        'raptor-webaudio-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-firefox',
+          buildType: 'opt',
+        },
+        'raptor-webaudio-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'WebAudio',
+    },
+  },
+};
+
+export default WIN10_CONFIG;

--- a/src/configuration/js-team/win7.js
+++ b/src/configuration/js-team/win7.js
@@ -1,0 +1,138 @@
+import { SETTINGS } from '../appDefaults';
+
+const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+
+const WIN7_CONFIG = {
+  label: 'Windows 7 32bit',
+  benchmarks: {
+    kraken: {
+      compare: {
+        kraken: {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: TALOS_FRAMEWORK_ID,
+          suite: 'kraken',
+          buildType: 'opt',
+          extraOptions: ['e10s', 'stylo'],
+        },
+      },
+      label: 'Kraken',
+    },
+    'motionmark-animometer': {
+      compare: {
+        'raptor-motionmark-animometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-animometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-animometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark Animometer',
+    },
+    'motionmark-htmlsuite': {
+      compare: {
+        'raptor-motionmark-htmlsuite-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-firefox',
+          buildType: 'opt',
+        },
+        'raptor-motionmark-htmlsuite-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-motionmark-htmlsuite-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'MotionMark HtmlSuite',
+    },
+    speedometer: {
+      compare: {
+        'raptor-speedometer-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-firefox',
+          buildType: 'opt',
+        },
+        'raptor-speedometer-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-speedometer-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'Speedometer',
+    },
+    stylebench: {
+      compare: {
+        'raptor-stylebench-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-firefox',
+          buildType: 'opt',
+        },
+        'raptor-stylebench-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-stylebench-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'StyleBench',
+    },
+    sunspider: {
+      compare: {
+        'raptor-sunspider-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-firefox',
+          buildType: 'opt',
+        },
+        'raptor-sunspider-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-sunspider-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'SunSpider',
+    },
+    webaudio: {
+      compare: {
+        'raptor-webaudio-firefox': {
+          color: '#e55525',
+          label: 'Firefox',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-firefox',
+          buildType: 'opt',
+        },
+        'raptor-webaudio-chrome': {
+          color: '#ffcd02',
+          label: 'Chrome',
+          frameworkId: RAPTOR_FRAMEWORK_ID,
+          suite: 'raptor-webaudio-chrome',
+          buildType: 'opt',
+        },
+      },
+      label: 'WebAudio',
+    },
+  },
+};
+
+export default WIN7_CONFIG;

--- a/src/configuration/js-team/win7.js
+++ b/src/configuration/js-team/win7.js
@@ -1,8 +1,8 @@
-import { SETTINGS } from '../appDefaults';
+import SETTINGS from '../perfherderSettings';
 
-const { TALOS_FRAMEWORK_ID, RAPTOR_FRAMEWORK_ID } = SETTINGS.frameworks;
+const { frameworkIds } = SETTINGS;
 
-const WIN7_CONFIG = {
+const Win7Config = {
   label: 'Windows 7 32bit',
   benchmarks: {
     kraken: {
@@ -10,7 +10,7 @@ const WIN7_CONFIG = {
         kraken: {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: TALOS_FRAMEWORK_ID,
+          frameworkId: frameworkIds.talos,
           suite: 'kraken',
           buildType: 'opt',
           extraOptions: ['e10s', 'stylo'],
@@ -23,14 +23,14 @@ const WIN7_CONFIG = {
         'raptor-motionmark-animometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-animometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-animometer-chrome',
           buildType: 'opt',
         },
@@ -42,14 +42,14 @@ const WIN7_CONFIG = {
         'raptor-motionmark-htmlsuite-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-firefox',
           buildType: 'opt',
         },
         'raptor-motionmark-htmlsuite-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-motionmark-htmlsuite-chrome',
           buildType: 'opt',
         },
@@ -61,14 +61,14 @@ const WIN7_CONFIG = {
         'raptor-speedometer-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-firefox',
           buildType: 'opt',
         },
         'raptor-speedometer-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-speedometer-chrome',
           buildType: 'opt',
         },
@@ -80,14 +80,14 @@ const WIN7_CONFIG = {
         'raptor-stylebench-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-firefox',
           buildType: 'opt',
         },
         'raptor-stylebench-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-stylebench-chrome',
           buildType: 'opt',
         },
@@ -99,14 +99,14 @@ const WIN7_CONFIG = {
         'raptor-sunspider-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-firefox',
           buildType: 'opt',
         },
         'raptor-sunspider-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-sunspider-chrome',
           buildType: 'opt',
         },
@@ -118,14 +118,14 @@ const WIN7_CONFIG = {
         'raptor-webaudio-firefox': {
           color: '#e55525',
           label: 'Firefox',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-firefox',
           buildType: 'opt',
         },
         'raptor-webaudio-chrome': {
           color: '#ffcd02',
           label: 'Chrome',
-          frameworkId: RAPTOR_FRAMEWORK_ID,
+          frameworkId: frameworkIds.raptor,
           suite: 'raptor-webaudio-chrome',
           buildType: 'opt',
         },
@@ -135,4 +135,4 @@ const WIN7_CONFIG = {
   },
 };
 
-export default WIN7_CONFIG;
+export default Win7Config;

--- a/src/configuration/perfherderSettings.js
+++ b/src/configuration/perfherderSettings.js
@@ -1,0 +1,9 @@
+const SETTINGS = {
+  frameworkIds: {
+    talos: 1,
+    raptor: 10,
+    jsbench: 11,
+  },
+};
+
+export default SETTINGS;

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -15,7 +15,7 @@ const fetchData = async (platform, benchmark, range) => {
       .map(async (modeKey) => {
         const benchmarkOptions = linux64.benchmarks[configUID].compare[modeKey];
         const seriesConfig = {
-          platform: platforms[platform].platform,
+          platform: platforms[platform].platform, // get platform against benchmark
           option: benchmarkOptions.buildType,
           ...benchmarkOptions,
         };

--- a/src/utils/prepareData.js
+++ b/src/utils/prepareData.js
@@ -1,5 +1,6 @@
 import { parse } from 'query-string';
-import { BENCHMARKS } from '../config';
+// import { BENCHMARKS } from '../config';
+import linux64 from '../configuration/js-team/linux64';
 
 // eslint-disable-next-line arrow-body-style
 const sortByLabel = (a, b) => {
@@ -43,8 +44,8 @@ const generateChartJsOptions = (configUID, meta) => {
   const higherIsBetter = (meta.lower_is_better === false);
   const reversed = higherIsBetter;
   let yLabel = higherIsBetter ? 'Score' : 'Execution time (ms)';
-  if (BENCHMARKS[configUID].scaleLabel) {
-    yLabel = BENCHMARKS[configUID].scaleLabel;
+  if (linux64.benchmarks[configUID].scaleLabel) {
+    yLabel = linux64.benchmarks[configUID].scaleLabel;
   }
   return chartJsOptions(reversed, yLabel);
 };
@@ -64,7 +65,7 @@ const prepareData = (benchmarks) => {
       };
     }
     const uid = meta.test ? meta.test : `${configUID}-overview`;
-    const title = meta.test ? meta.test : BENCHMARKS[configUID].label;
+    const title = meta.test ? meta.test : linux64.benchmarks[configUID].label;
 
     if (!newData.graphs[uid]) {
       newData.graphs[uid] = {

--- a/src/utils/validCombination.js
+++ b/src/utils/validCombination.js
@@ -1,9 +1,10 @@
-import { CONFIG, TIMERANGE_UPPER_LIMIT } from '../config';
+import { TIMERANGE_UPPER_LIMIT } from '../config';
+import platforms from '../configuration/js-team/index';
 
 const validCombination = (platform, benchmark, timeRange) => (
-  CONFIG.platforms[platform] && (
+  platforms[platform] && (
     benchmark === 'overview'
-    || CONFIG.platforms[platform].benchmarks.includes(benchmark)
+    || (benchmark in platforms[platform].benchmarks)
   ) && (
     !!Math.round(timeRange) && parseInt(timeRange, 10) <= TIMERANGE_UPPER_LIMIT
   )

--- a/test/components/Pickers.test.jsx
+++ b/test/components/Pickers.test.jsx
@@ -3,6 +3,25 @@ import renderer from 'react-test-renderer';
 import 'raf/polyfill';
 import Pickers from '../../src/components/Pickers';
 
+const benchmarkOptions = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'kraken', label: 'Kraken' },
+  { value: 'motionmark-animometer', label: 'MotionMark Animometer' },
+  { value: 'motionmark-htmlsuite', label: 'MotionMark HtmlSuite' },
+  { value: 'speedometer', label: 'Speedometer' },
+  { value: 'stylebench', label: 'StyleBench' },
+  { value: 'sunspider', label: 'SunSpider' },
+  { value: 'webaudio', label: 'WebAudio' },
+];
+
+const platformOptions = [
+  { value: 'linux64', label: 'Linux 64bit' },
+  { value: 'mac', label: 'Mac OS X' },
+  { value: 'win7', label: 'Windows 7 32bit' },
+  { value: 'win10', label: 'Windows 10 64bit' },
+  { value: 'android', label: 'Android' },
+];
+
 it('renders correctly', () => {
   const tree = renderer
     .create((
@@ -10,6 +29,8 @@ it('renders correctly', () => {
         platform="win10"
         benchmark="overview"
         onChange={() => {}}
+        benchmarkOptions={benchmarkOptions}
+        platformOptions={platformOptions}
       />
     ))
     .toJSON();


### PR DESCRIPTION
Hi @armenzg, This experimental PR is to solve issue #97 and #82 as both are interlinked. 

Just to recall we left issue 82 on [this note](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/pull/93#discussion_r227780852). 

For issue 97 in my understanding we want <platform>-nightly in all platforms rather than using <platform>.
And as per [your hint](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/issues/97#issuecomment-432373404) I have added` platform: linux64-nightly` for all chrome data in js-teams/linux.js. ( Please see diff ) 

Q1: We need to add this `<platform>-nightly` against chrome in all platforms files as well like wind10-nightly, win7-nightly etc. Right?

Now connecting the dots,[ you said in last PR](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/pull/93#discussion_r227481242) that we can refactor fetchData and get rid of `platform` which now make sense after changing platform to nightly for chrome becuase now our benchmarks don't have common platform to get data. 

if we remove platform from fetchData then I think there no purpose of [platforms defined here](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/compare/master...aimenbatool:refactor-config-logic-test2?expand=1#diff-8bbfcb18cbc1315515dc0b863ede77e2R7) for two reasons. 
- we are not going to use this platform config further
- now our benchmarks don't have common platform `(<platform>  vs <platform>-nightly)
`
So, solution revolves somewhere around benchmarks and platfroms inside benchmarks. I am not sure about this but what about [geting platform against benchmark](https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/compare/master...aimenbatool:refactor-config-logic-test2?expand=1#diff-8bbfcb18cbc1315515dc0b863ede77e2R7).

Would you like to give any hint or tips to solve it better? Or mention something which can help me. 
I think solving issue 97 within 82 is good because we have already refactored it to the required changes. 

Q2: Why chrom data for JSbench benchmarks is available upto date with linux64? e.g ( Six-speed, Octane etc) And why not others with same config?

It would be a great help if you give me small tasks to do. It will be less overwhelming and I wil be able to break down big fish into smaller to eat. I think a lot is done in previous PR and we are closer to some solution but how much closer, I am not sure about this. 

Thanks a lot for your **patience**. :bowing_woman: 