### PR TITLE
Use new version of perf-goggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@material-ui/core": "^3",
     "@material-ui/icons": "^3",
     "@material-ui/lab": "3.0.0-alpha.18",
-    "@mozilla-frontend-infra/perf-goggles": "^2.0.1",
+    "@mozilla-frontend-infra/perf-goggles": "^3.0.0",
     "chart.js": "^2",
     "prop-types": "^15",
     "query-string": "^6",

--- a/src/utils/fetchData.js
+++ b/src/utils/fetchData.js
@@ -18,7 +18,7 @@ const fetchData = async (platform, benchmark, range) => {
           ...benchmarkOptions,
         };
         const data = await queryPerfData(
-          seriesConfig, includeSubtests, convertToSeconds(timeRange),
+          seriesConfig, { includeSubtests, timeRange: convertToSeconds(timeRange) },
         );
         if (data) {
           const { suite } = benchmarkOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -731,10 +731,10 @@
     classnames "^2.2.5"
     keycode "^2.1.9"
 
-"@mozilla-frontend-infra/perf-goggles@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-2.0.1.tgz#514bb39128beb07e29882849607d0efa90284fb8"
-  integrity sha512-ehl5ZGG5I0il+U3h21ZQ8ZfRfTq/Xl3SIURK46gseYLHVC3dBVx/XHMIAP0hjA0ScY/U7faMlhr6k8QdJtk0kQ==
+"@mozilla-frontend-infra/perf-goggles@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@mozilla-frontend-infra/perf-goggles/-/perf-goggles-3.0.0.tgz#b8c6d4f2dc83f22f8bec153b0afe5bec52ba1438"
+  integrity sha512-DcUZXc/zRF5CN3QWL72hBjojhnKwzsDvprja1HMeZTwhi1wl5fDS7/OJr+ztumt0k9Pi+Z2BQngsgaTLudMUtA==
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash.isequal "^4.5.0"


### PR DESCRIPTION
This is simply to keep in sync with Firefox Health upgrading versions.