### PR TITLE
Fix: show all configurations in the drilldown page

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1939,7 +1939,6 @@ export const CONFIG = {
       const suffix = '-shippable';
       return platform.endsWith(suffix) ? platform : `${platform}${suffix}`;
     },
-
   },
   views: {
     linux64: {
@@ -2025,12 +2024,14 @@ export const queryInfo = (viewConfig, benchmark) => {
     });
   } else {
     Object.values(BENCHMARKS[benchmark].compare).forEach((seriesConfig) => {
-      info[benchmark] = {
-        compare: [],
-        benchmarkUID: benchmark,
-        includeSubtests: true,
-        label: BENCHMARKS[benchmark].label,
-      };
+      if (!info[benchmark]) {
+        info[benchmark] = {
+          compare: [],
+          benchmarkUID: benchmark,
+          includeSubtests: true,
+          label: BENCHMARKS[benchmark].label,
+        };
+      }
       const oneOrMoreSeries = processSeries(seriesConfig, viewConfig);
       info[benchmark].compare = info[benchmark].compare.concat(oneOrMoreSeries);
     });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,4 +1,4 @@
-import { BENCHMARKS, CONFIG } from '../src/config';
+import { BENCHMARKS, CONFIG, queryInfo } from '../src/config';
 
 it('Verify all benchmarks are defined', () => {
   Object.values(CONFIG.views).map(({ benchmarks }) => (
@@ -9,4 +9,57 @@ it('Verify all benchmarks are defined', () => {
       }
     })
   ));
+});
+
+it('Query info', () => {
+  const benchmarks = queryInfo(CONFIG.views.linux64, 'wasm-misc');
+  expect(benchmarks).toStrictEqual({
+    'wasm-misc': {
+      benchmarkUID: 'wasm-misc',
+      compare: [
+        {
+          color: '#e55525',
+          label: 'Firefox (tiering)',
+          frameworkId: 10,
+          suite: 'raptor-wasm-misc-firefox',
+          option: 'opt',
+          platform: 'linux64',
+        },
+        {
+          color: 'red',
+          label: 'Firefox (wasm-baseline)',
+          frameworkId: 10,
+          suite: 'raptor-wasm-misc-baseline-firefox',
+          option: 'opt',
+          platform: 'linux64',
+        },
+        {
+          color: 'brown',
+          label: 'Firefox (wasm-ion)',
+          frameworkId: 10,
+          suite: 'raptor-wasm-misc-ion-firefox',
+          option: 'opt',
+          platform: 'linux64',
+        },
+        {
+          color: 'yellow',
+          label: 'Firefox (wasm-cranelift)',
+          frameworkId: 10,
+          suite: 'raptor-wasm-misc-cranelift-firefox',
+          option: 'opt',
+          platform: 'linux64',
+        },
+        {
+          color: '#4285F4',
+          label: 'Chromium',
+          frameworkId: 10,
+          suite: 'raptor-wasm-misc-chromium',
+          option: 'opt',
+          platform: 'linux64-shippable',
+        },
+      ],
+      includeSubtests: true,
+      label: 'WebAssembly Embenchen',
+    },
+  });
 });


### PR DESCRIPTION
Fixes issue #202

This is a fallout from https://github.com/mozilla-frontend-infra/firefox-performance-dashboard/pull/198

The overview page would look fine, however, the drilldown would only show one platform:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/44410/64459593-4585a800-d0c6-11e9-97a4-5975a5d51152.png">

After the fix we can see all configurations:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/44410/64459647-64843a00-d0c6-11e9-807a-a7495f434b16.png">