### PR TITLE
Reconfigure Renovate

### DIFF
--- a/.renovaterc
+++ b/.renovaterc
@@ -1,9 +1,15 @@
 {
   "extends": [
-    "automergePatch",
     "schedule:earlyMondays"
   ],
   "minor": {
     "enabled": false
+  }
+  "separateMinorPatch": true,
+  "patch": {
+    "automerge": true
+  },
+  "lockFileMaintenance": {
+    "automerge": true
   }
 }


### PR DESCRIPTION
It seems that the `automergePatch` package is not available regardless of what the code says:

* https://docs.renovatebot.com/presets-default/#automergepatch
* https://github.com/renovatebot/presets/blob/master/packages/renovate-config-default/package.json#L277-L289

Fixes #261